### PR TITLE
Use Magento 2.3.2-p2 for integration testing (instead of 2.3.2).

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,9 +211,9 @@ jobs:
       - image: 244249143763.dkr.ecr.us-west-2.amazonaws.com/ns8-magento:7.1-2.3.1
     steps:
       - test
-  test_7-1_2-3-2:
+  test_7-1_2-3-2-p2:
     docker:
-      - image: 244249143763.dkr.ecr.us-west-2.amazonaws.com/ns8-magento:7.1-2.3.2
+      - image: 244249143763.dkr.ecr.us-west-2.amazonaws.com/ns8-magento:7.1-2.3.2-p2
     steps:
       - test
   test_7-1_2-3-3:
@@ -231,9 +231,9 @@ jobs:
       - image: 244249143763.dkr.ecr.us-west-2.amazonaws.com/ns8-magento:7.2-2.3.1
     steps:
       - test
-  test_7-2_2-3-2:
+  test_7-2_2-3-2-p2:
     docker:
-      - image: 244249143763.dkr.ecr.us-west-2.amazonaws.com/ns8-magento:7.2-2.3.2
+      - image: 244249143763.dkr.ecr.us-west-2.amazonaws.com/ns8-magento:7.2-2.3.2-p2
     steps:
       - test
   test_7-2_2-3-3:
@@ -304,7 +304,7 @@ workflows:
       - test_7-1_2-3-1:
           requires:
             - approve
-      - test_7-1_2-3-2:
+      - test_7-1_2-3-2-p2:
           requires:
             - approve
       - test_7-1_2-3-3:
@@ -316,7 +316,7 @@ workflows:
       - test_7-2_2-3-1:
           requires:
             - approve
-      - test_7-2_2-3-2:
+      - test_7-2_2-3-2-p2:
           requires:
             - approve
       - test_7-2_2-3-3:
@@ -344,11 +344,11 @@ workflows:
           requires:
             #- test_7-1_2-3-0
             - test_7-1_2-3-1
-            - test_7-1_2-3-2
+            - test_7-1_2-3-2-p2
             - test_7-1_2-3-3
             #- test_7-2_2-3-0
             - test_7-2_2-3-1
-            - test_7-2_2-3-2
+            - test_7-2_2-3-2-p2
             - test_7-2_2-3-3
             - test_7-2_2-3-4
             - test_7-2_2-3-4-p2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,11 +241,6 @@ jobs:
       - image: 244249143763.dkr.ecr.us-west-2.amazonaws.com/ns8-magento:7.2-2.3.3
     steps:
       - test
-  test_7-2_2-3-4:
-    docker:
-      - image: 244249143763.dkr.ecr.us-west-2.amazonaws.com/ns8-magento:7.2-2.3.4
-    steps:
-      - test
   test_7-2_2-3-4-p2:
     docker:
       - image: 244249143763.dkr.ecr.us-west-2.amazonaws.com/ns8-magento:7.2-2.3.4-p2
@@ -259,11 +254,6 @@ jobs:
   test_7-3_2-3-3:
     docker:
       - image: 244249143763.dkr.ecr.us-west-2.amazonaws.com/ns8-magento:7.3-2.3.3
-    steps:
-      - test
-  test_7-3_2-3-4:
-    docker:
-      - image: 244249143763.dkr.ecr.us-west-2.amazonaws.com/ns8-magento:7.3-2.3.4
     steps:
       - test
   test_7-3_2-3-4-p2:
@@ -322,9 +312,6 @@ workflows:
       - test_7-2_2-3-3:
           requires:
             - approve
-      - test_7-2_2-3-4:
-          requires:
-            - approve
       - test_7-2_2-3-4-p2:
           requires:
             - approve
@@ -332,9 +319,6 @@ workflows:
           requires:
             - approve
       - test_7-3_2-3-3:
-          requires:
-            - approve
-      - test_7-3_2-3-4:
           requires:
             - approve
       - test_7-3_2-3-4-p2:
@@ -350,9 +334,7 @@ workflows:
             - test_7-2_2-3-1
             - test_7-2_2-3-2-p2
             - test_7-2_2-3-3
-            - test_7-2_2-3-4
             - test_7-2_2-3-4-p2
             - test_7-2_2-3-5-p1
             - test_7-3_2-3-3
-            - test_7-3_2-3-4
             - test_7-3_2-3-4-p2


### PR DESCRIPTION
## Clubhouse Stories

## Summary

Magento released an updated version of 2.3.2 with security patches (Magento 2.3.2-p2), so we should use that for integration testing (instead of the original 2.3.2).

Also, testing on both 2.3.4 and 2.3.4-p2 seems pretty redundant, as the only difference is the security patches (regular bug fixes don't get included in the release patches). Tests are somewhat time consuming and currently use more than the company's allotment of CircleCI containers, so I think it makes sense to only test on the latest version of each Magento release.

## Author Checklist

I have added/updated:

- [X] Tests
- [ ] Documentation
- [ ] Release notes

## Version Bump

- [ ] Patch (bug fix - backwards compatible)
- [ ] Minor (new functionality - backwards compatible)
- [ ] Major (significant change - not backwards compatible)
