### PR TITLE
[ch-36618] Fix scores in Orders showing NA when they're actually 0

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -223,6 +223,21 @@ class Order extends AbstractHelper
     }
 
     /**
+     * Gets local EQ8 scores for a set of order IDs
+     * Does not verify that all order IDs provided were found
+     * @param array $orderIds
+     * @return Collection the found orders
+     */
+    public function getOrderEQ8Scores(array $orderIds): Collection
+    {
+        return $this->orderCollectionFactory->create()
+             ->addFieldToSelect(OrderInterface::ENTITY_ID)
+             ->addFieldToSelect(self::EQ8_SCORE_COL)
+             ->addFieldToFilter(OrderInterface::ENTITY_ID, ['in' => $orderIds])
+             ;
+    }
+
+    /**
      * Sets the EQ8 Score on an order
      * @param int $eq8Score The score to persist
      * @param OrderInterface $order The order to update


### PR DESCRIPTION
# Story Reference

[36618](https://app.clubhouse.io/ns8/story/36618)

## Summary

The EQ8 score was always showing as NA (regardless of actual value in `sales_order.protect_eq8_score`), which was tracked to the UI data provider. Magento was passing that class a set of partial orders. Solution is to fetch the orders' scores in bulk and populate the partial orders with those scores.

## Author Checklist

I have added/updated:

- [ ] Tests
- [x] Documentation
- [x] Release notes (title of this PR)

## Version Bump

- [x] Patch (bug fix - backwards compatible)
- [ ] Minor (new functionality - backwards compatible)
- [ ] Major (significant change - not backwards compatible)
