### PR TITLE
Updating Init Access Token call after Merge Conflict CH-36937

### DIFF
--- a/Helper/Queue.php
+++ b/Helper/Queue.php
@@ -106,7 +106,7 @@ class Queue extends AbstractHelper
     public function fetchQueueUrl(int $storeId) : string
     {
         try {
-            $this->config->initSdkConfiguration($storeId);
+            $this->config->initSdkConfiguration(true, $storeId);
             $sdkHttpClient = new HttpClient();
             $urlData = $sdkHttpClient->post(QueueClient::GET_QUEUE_URL);
             return $urlData->url;


### PR DESCRIPTION
# Story Reference

[CH-36937](https://app.clubhouse.io/ns8/story/36937/update-polling-logic-to-pull-from-every-enabled-shop-queue)

## Summary
This change updates polling logic to support multiple Magento stores per merchant

## Author Checklist

I have added/updated:

- [X] Tests
- [N/A] Documentation
- [X] Release notes (title of this PR)

## Version Bump

- [ ] Patch (bug fix - backwards compatible)
- [X] Minor (new functionality - backwards compatible)
- [ ] Major (significant change - not backwards compatible)
