### PR TITLE
Initializing Order Send/Update event with Store ID CH-36884

### DIFF
--- a/Observer/OrderUpdate.php
+++ b/Observer/OrderUpdate.php
@@ -157,7 +157,7 @@ class OrderUpdate implements ObserverInterface
             }
             // Version our changes to this data structure
             $orderData['ns8_version'] = 2;
-            $this->config->initSdkConfiguration();
+            $this->config->initSdkConfiguration(true, $currentOrder->getStoreId());
             $orderData['session'] = $this->sessionHelper->getSessionData();
             ActionsClient::setAction($action, $orderData);
         } catch (Throwable $e) {


### PR DESCRIPTION
# Story Reference

[ CH-36884](https://app.clubhouse.io/ns8/story/36884/pass-access-token-to-sdk-when-creating-an-order_)

## Summary

Permits order creation for multistore Magento installations.

## Author Checklist

I have added/updated:

- [N/A] Tests
- [N/A] Documentation
- [N/A] Release notes (title of this PR)

## Version Bump

- [ ] Patch (bug fix - backwards compatible)
- [X] Minor (new functionality - backwards compatible)
- [ ] Major (significant change - not backwards compatible)
