### PR TITLE
[ch-36869] Sort shops based on Protect-active in dropdown

### DIFF
--- a/Block/Adminhtml/StoreSelect.php
+++ b/Block/Adminhtml/StoreSelect.php
@@ -52,10 +52,12 @@ class StoreSelect extends Template
         return array_map(function ($store) {
             return [
                 "id" => $store["id"],
-                "active" => $store["active"],
+                "active" => $this->config->isMerchantActive((int) $store["id"]),
                 "name" => $store["name"],
                 "token" => $this->config->getAccessToken((int) $store["id"])
             ];
-        }, $stores);
+        }, array_filter($stores, function ($store) {
+            return $store["active"];
+        }));
     }
 }


### PR DESCRIPTION
# Story Reference

[ch36869](https://app.clubhouse.io/ns8/story/36869/)

## Summary

Accidentally sorted shops in the dropdown on their Magento isActive flag, not Protect.

## Author Checklist

I have added/updated:

- [ ] Tests
- [ ] Documentation
- [x] Release notes (title of this PR)

## Version Bump

- [x] Patch (bug fix - backwards compatible)
- [ ] Minor (new functionality - backwards compatible)
- [ ] Major (significant change - not backwards compatible)
