### PR TITLE
[ch-36869] Hide dropdown when only one store is accessible

### DIFF
--- a/view/adminhtml/templates/store_select.phtml
+++ b/view/adminhtml/templates/store_select.phtml
@@ -96,6 +96,12 @@ $block = $block;
       });
       renderProtectIFrame(store.token);
     });
+
+    if (stores.length <= 1) {
+      // .next() used to get the actual visible select2 container
+      $("#ns8-store-select").next().hide();
+    }
+
     $("#ns8-store-select").trigger("change");
   });
 </script>


### PR DESCRIPTION
# Story Reference

[ch36869](https://app.clubhouse.io/ns8/story/36869/)

## Summary

Correctly hide dropdown with <2 stores per ticket

## Author Checklist

I have added/updated:

- [ ] Tests
- [ ] Documentation
- [x] Release notes (title of this PR)

## Version Bump

- [x] Patch (bug fix - backwards compatible)
- [ ] Minor (new functionality - backwards compatible)
- [ ] Major (significant change - not backwards compatible)
