### PR TITLE
[39022] [39017] Add install functionality when adding new shops

### DIFF
--- a/Block/Adminhtml/Container.php
+++ b/Block/Adminhtml/Container.php
@@ -15,9 +15,11 @@ use Magento\Backend\Block\Template\Context;
 use Magento\Framework\App\Request\Http;
 use Magento\Framework\Event\ManagerInterface;
 use Magento\Framework\View\Result\PageFactory;
+use Magento\Store\Model\StoreManagerInterface;
 use NS8\Protect\Helper\Config;
 use NS8\Protect\Helper\Order;
 use NS8\Protect\Helper\Url;
+use NS8\Protect\Helper\Store;
 use NS8\ProtectSDK\ClientSdk\Client as ClientSdkClient;
 
 /**
@@ -84,7 +86,8 @@ class Container extends Template
         ManagerInterface $eventManager,
         Http $request,
         Order $order,
-        PageFactory $resultPageFactory
+        PageFactory $resultPageFactory,
+        Store $storeHelper
     ) {
         parent::__construct($context);
         $this->config = $config;
@@ -94,7 +97,11 @@ class Container extends Template
         $this->request = $request;
         $this->resultPageFactory = $resultPageFactory;
 
-        $this->eventManager->dispatch('ns8_protect_dashboard_container_instantiated');
+        $storeId = $request->getParam('store_id', $storeHelper->getCurrentStore()['id']);
+        $this->eventManager->dispatch(
+            'ns8_protect_dashboard_container_instantiated',
+            ['storeId' => $storeId]
+        );
     }
 
     /**

--- a/Block/Adminhtml/Container.php
+++ b/Block/Adminhtml/Container.php
@@ -18,8 +18,8 @@ use Magento\Framework\View\Result\PageFactory;
 use Magento\Store\Model\StoreManagerInterface;
 use NS8\Protect\Helper\Config;
 use NS8\Protect\Helper\Order;
-use NS8\Protect\Helper\Url;
 use NS8\Protect\Helper\Store;
+use NS8\Protect\Helper\Url;
 use NS8\ProtectSDK\ClientSdk\Client as ClientSdkClient;
 
 /**

--- a/Block/Adminhtml/StoreSelect.php
+++ b/Block/Adminhtml/StoreSelect.php
@@ -7,8 +7,8 @@ use Magento\Backend\Block\Template\Context;
 use Magento\Framework\App\Request\Http;
 use Magento\Store\Model\StoreManagerInterface;
 use NS8\Protect\Helper\Config;
-use NS8\Protect\Helper\Url;
 use NS8\Protect\Helper\Store;
+use NS8\Protect\Helper\Url;
 
 /**
  * Provides access to DI and helper methods for the store_select template

--- a/Block/Adminhtml/StoreSelect.php
+++ b/Block/Adminhtml/StoreSelect.php
@@ -4,9 +4,11 @@ namespace NS8\Protect\Block\Adminhtml;
 
 use Magento\Backend\Block\Template;
 use Magento\Backend\Block\Template\Context;
+use Magento\Framework\App\Request\Http;
+use Magento\Store\Model\StoreManagerInterface;
 use NS8\Protect\Helper\Config;
-use NS8\Protect\Helper\Store;
 use NS8\Protect\Helper\Url;
+use NS8\Protect\Helper\Store;
 
 /**
  * Provides access to DI and helper methods for the store_select template
@@ -20,24 +22,33 @@ class StoreSelect extends Template
     public $url;
 
     /** @var Store */
-    private $storeHelper;
+    public $storeHelper;
 
+    /**
+     * The request.
+     *
+     * @var Http
+     */
+    public $request;
     /**
      * Constructor
      * @param Context $context The context
      * @param Config $config Config helper
      * @param Url $url Url helper
+     * @param Http $request request object
      * @param Store $storeHelper Store helper
      */
     public function __construct(
         Context $context,
         Config $config,
         Url $url,
+        Http $request,
         Store $storeHelper
     ) {
         $this->config = $config;
         $this->url = $url;
         $this->storeHelper = $storeHelper;
+        $this->request = $request;
         parent::__construct($context);
     }
 
@@ -54,7 +65,7 @@ class StoreSelect extends Template
                 "id" => $store["id"],
                 "active" => $this->config->isMerchantActive((int) $store["id"]),
                 "name" => $store["name"],
-                "token" => $this->config->getAccessToken((int) $store["id"])
+                "token" => $this->config->getAccessToken((int) $store["id"]),
             ];
         }, array_filter($stores, function ($store) {
             return $store["active"];

--- a/Controller/Adminhtml/Sales/Dashboard.php
+++ b/Controller/Adminhtml/Sales/Dashboard.php
@@ -54,7 +54,7 @@ class Dashboard extends Action
         $this->config = $config;
 
         // Init SDK Configuration before invoking HTTP Client:wq
-        
+
         $this->config->initSdkConfiguration();
         $this->loggingClient = new LoggingClient();
         $this->merchantsClient = new MerchantsClient();

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -232,7 +232,7 @@ class Config extends AbstractHelper
         $metadatas = $this->getStoreMetadatas();
         $storeId = $storeId !== null ? $storeId : self::EMPTY_STORE_ID;
         return isset($metadatas[$storeId]) ? $metadatas[$storeId] : (
-            isset($metadatas[self::EMPTY_STORE_ID]) ? $metadatas[self::EMPTY_STORE_ID] : null
+            isset($metadatas[self::EMPTY_STORE_ID]) && count($metadatas) === 1 ? $metadatas[self::EMPTY_STORE_ID] : null
         );
     }
 

--- a/Helper/Store.php
+++ b/Helper/Store.php
@@ -41,6 +41,22 @@ class Store extends AbstractHelper
     }
 
     /**
+     *  formats a single store into a more succinct and usable array
+     * @param Store $store
+     * @return array
+     */
+    private function parseStore($store): array
+    {
+        return [
+            'name'  => $store->getName(),
+            'code'  => $store->getCode(),
+            'id'    => $store->getStoreId(),
+            'url'   => $store->getBaseUrl(),
+            'active' => $store->isActive()
+        ];
+    }
+
+    /**
      * Formats store collections into a more succinct and usable array
      * @param array $storeCollection
      * @return array
@@ -49,13 +65,7 @@ class Store extends AbstractHelper
     {
         $stores = [];
         foreach ($storeCollection as $value) {
-            $stores[] = [
-                'name'  => $value->getName(),
-                'code'  => $value->getCode(),
-                'id'    => $value->getStoreId(),
-                'url'   => $value->getBaseUrl(),
-                'active' => $value->isActive()
-            ];
+            $stores[] = $this->parseStore($value);
         }
         return $stores;
     }
@@ -91,5 +101,13 @@ class Store extends AbstractHelper
     {
         $storeManagerDataList = $this->storeManager->getStores();
         return $this->parseStores($storeManagerDataList);
+    }
+
+    /**
+     * get the current store from the storeManager
+     */
+    public function getCurrentStore(): array
+    {
+        return $this->parseStore($this->storeManager->getStore());
     }
 }

--- a/Setup/Uninstall.php
+++ b/Setup/Uninstall.php
@@ -66,7 +66,7 @@ class Uninstall implements UninstallInterface
             $setup->startSetup();
             $metadatas = $this->config->getStoreMetadatas();
             foreach ($metadatas as $id => $metadata) {
-                $this->uninstallMerchant($id, $metadata);
+                $this->uninstallMerchant((int) $id, $metadata);
             }
         } catch (Throwable $e) {
             $this->loggingClient->error('Protect uninstall failed', $e);

--- a/view/adminhtml/templates/store_select.phtml
+++ b/view/adminhtml/templates/store_select.phtml
@@ -11,6 +11,7 @@ $block = $block;
 <select id="ns8-store-select"></select>
 
 <script type="text/javascript" src="<?= $block->url->getProtectClientSdkUrl() ?>"></script>
+
 <script>
   require([
     "jquery",
@@ -25,7 +26,7 @@ $block = $block;
     var orderIncrementId = '<?= $block->getOrderIncrementIdFromRequest(); ?>';
     var stores = JSON.parse('<?= json_encode($block->getStores()) ?>');
     var clientUrl = '<?= $block->url->getClientUrl() ?>';
-
+    var paramStoreId = '<?= $block->request->getParam('store_id', $block->storeHelper->getCurrentStore()['id']) ?>';
     function navigateToMagentoOrderDetails(orderData) {
       var orderDetailsUrlBase = '<?= $block->url->getMagentOrderDetailUrl(); ?>';
       window.location.href = orderDetailsUrlBase + '/' + orderData.orderId;
@@ -43,6 +44,7 @@ $block = $block;
           classNames: ['ns8-protect-client-iframe'],
         },
       });
+
       var protectClient = Protect.createClient(clientConfig);
       $('#' + containerElementId).html('');
       protectClient.render(requestedPage, orderIncrementId);
@@ -60,9 +62,11 @@ $block = $block;
     var activeStores = stores.filter(function(store) {
       return !!store.active;
     });
+
     var inactiveStores = stores.filter(function(store) {
       return !store.active;
     });
+
     var storeOptions = _.compact([
       activeStores.length > 0 ? {
         text: 'Active Stores',
@@ -89,18 +93,25 @@ $block = $block;
       minimumResultsForSearch: Infinity, // disable search
       width: '25%'
     });
+
     $("#ns8-store-select").on("change", function() {
       var storeId = this.value.toString();
       var store = stores.find(function(store) {
         return store.id === storeId;
       });
-      renderProtectIFrame(store.token);
+      if (storeId !== paramStoreId) {
+        const newUrl = '<?=$block->getUrl('*/*/*')?>' + '?store_id=' + storeId;
+        window.location = newUrl;
+      } else {
+        renderProtectIFrame(store.token);
+      }
     });
 
     if (stores.length <= 1) {
       // .next() used to get the actual visible select2 container
       $("#ns8-store-select").next().hide();
     }
+    $("#ns8-store-select").val(paramStoreId)
 
     $("#ns8-store-select").trigger("change");
   });

--- a/view/adminhtml/templates/store_select.phtml
+++ b/view/adminhtml/templates/store_select.phtml
@@ -116,5 +116,6 @@ $block = $block;
       // .next() used to get the actual visible select2 container
       $("#ns8-store-select").next().hide();
     }
+    $("#ns8-store-select").val(paramStoreId)
   });
 </script>

--- a/view/adminhtml/templates/store_select.phtml
+++ b/view/adminhtml/templates/store_select.phtml
@@ -112,7 +112,9 @@ $block = $block;
       $("#ns8-store-select").next().hide();
     }
     $("#ns8-store-select").val(paramStoreId)
-
-    $("#ns8-store-select").trigger("change");
+    if (stores.length <= 1) {
+      // .next() used to get the actual visible select2 container
+      $("#ns8-store-select").next().hide();
+    }
   });
 </script>


### PR DESCRIPTION
# Story Reference

[39022](https://app.clubhouse.io/ns8/story/39022)
[39017](https://app.clubhouse.io/ns8/story/39017)
## Summary

Got a twofer: I tweaked the shop dropdown to change routes instead of just reloading the iframe, and added a store_id query param. This allows both the iframe to resize appropriately, and fires off the dashboard instantiation event in magento (which starts the install process)

## Author Checklist

I have added/updated:

- [ ] Tests
- [ ] Documentation
- [ ] Release notes (title of this PR)

## Version Bump

- [ ] Patch (bug fix - backwards compatible)
- [ ] Minor (new functionality - backwards compatible)
- [ ] Major (significant change - not backwards compatible)
