### PR TITLE
[39994] Create Set Token Command for Magento

### DIFF
--- a/Console/Command/SetAccessToken.php
+++ b/Console/Command/SetAccessToken.php
@@ -1,0 +1,79 @@
+<?php
+namespace NS8\Protect\Console\Command;
+
+use NS8\Protect\Helper\Config;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Class SetAccessToken
+ *
+ * sets the access token in the store metadata config
+ */
+class SetAccessToken extends Command
+{
+    const STORE_ID = 'store';
+    const TOKEN = 'token';
+    const ACTIVE = 'active';
+
+    /**
+     * @inheritDoc
+     */
+    public function __construct(Config $config)
+    {
+        $this->config = $config;
+        parent::__construct();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function configure(): void
+    {
+        $this->setName('protect:token:set');
+        $this->setDescription('overwrites a store\'s installed access token');
+        $this->addOption(
+            self::STORE_ID,
+            null,
+            InputOption::VALUE_REQUIRED,
+            'store id'
+        );
+        $this->addOption(
+            self::ACTIVE,
+            null,
+            InputOption::VALUE_REQUIRED,
+            'is the merchant active'
+        );
+        $this->addArgument(
+            self::TOKEN,
+            InputArgument::REQUIRED,
+            'Protect token'
+        );
+
+        parent::configure();
+    }
+
+    /**
+     * Execute sets the store's access token
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     *
+     * @return void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): void
+    {
+        $storeId = $input->getOption(self::STORE_ID);
+        $token = $input->getArgument(self::TOKEN);
+        $active = $input->getOption(self::ACTIVE);
+
+        $this->config->setAccessToken($storeId, $token);
+        if ($active !== null) {
+            $this->config->setIsMerchantActive($storeId, $active === 'true');
+        }
+        $output->writeln('<info>Access token overwritten.</info>');
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -16,4 +16,11 @@
             <argument name="salesOrderGrid" xsi:type="object">Magento\Sales\Model\ResourceModel\Order\Grid</argument>
         </arguments>
     </type>
+    <type name="Magento\Framework\Console\CommandListInterface">
+        <arguments>
+            <argument name="commands" xsi:type="array">
+                <item name="setAccessTokenCommand" xsi:type="object">NS8\Protect\Console\Command\SetAccessToken</item>
+            </argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
…
# Story Reference

[39994](https://app.clubhouse.io/ns8/story/39994)

## Summary

create a new magento command `bin/magento protect:token:set [--store STORE] [--active ACTIVE] [--] <token>`
that allows us to set a magento token
## Author Checklist

I have added/updated:

- [ ] Tests
- [ ] Documentation
- [ ] Release notes (title of this PR)

## Version Bump

- [ ] Patch (bug fix - backwards compatible)
- [x] Minor (new functionality - backwards compatible)
- [ ] Major (significant change - not backwards compatible)
