### PR TITLE
Ctdoriott/ch40216/single order view fails to render

### DIFF
--- a/Block/Adminhtml/Container.php
+++ b/Block/Adminhtml/Container.php
@@ -97,7 +97,7 @@ class Container extends Template
         $this->order = $order;
         $this->request = $request;
         $this->resultPageFactory = $resultPageFactory;
-        $this->url = $url
+        $this->url = $url;
 
         $storeId = $request->getParam('store_id', $storeHelper->getCurrentStore()['id']);
         $this->eventManager->dispatch(
@@ -113,7 +113,8 @@ class Container extends Template
      */
     public function getInitialAccessToken() : string
     {
-        $storeId = $order->getStoreId();
+        $order = $this->order->getOrder();
+        $storeId = $order ? (int) $order->getStoreId() : null;
         $accessToken = $this->config->getAccessToken($storeId);
 
         return (string) $accessToken;

--- a/Block/Adminhtml/Container.php
+++ b/Block/Adminhtml/Container.php
@@ -87,7 +87,8 @@ class Container extends Template
         Http $request,
         Order $order,
         PageFactory $resultPageFactory,
-        Store $storeHelper
+        Store $storeHelper,
+        Url $url
     ) {
         parent::__construct($context);
         $this->config = $config;
@@ -96,12 +97,26 @@ class Container extends Template
         $this->order = $order;
         $this->request = $request;
         $this->resultPageFactory = $resultPageFactory;
+        $this->url = $url
 
         $storeId = $request->getParam('store_id', $storeHelper->getCurrentStore()['id']);
         $this->eventManager->dispatch(
             'ns8_protect_dashboard_container_instantiated',
             ['storeId' => $storeId]
         );
+    }
+
+    /**
+     * Get the page to navigate to within the protect client
+     *
+     * @return string Access token to use initially upon page render
+     */
+    public function getInitialAccessToken() : string
+    {
+        $storeId = $order->getStoreId();
+        $accessToken = $this->config->getAccessToken($storeId);
+
+        return (string) $accessToken;
     }
 
     /**

--- a/view/adminhtml/templates/order-review-tab.phtml
+++ b/view/adminhtml/templates/order-review-tab.phtml
@@ -1,4 +1,4 @@
 <section class="admin__page-section custom-tab-content">
-  <?= $block->getLayout()->createBlock('NS8\Protect\Block\Adminhtml\Container')->setTemplate('NS8_Protect::client_iframe.phtml')->toHtml(); ?>
+  <?= $block->getLayout()->createBlock('NS8\Protect\Block\Adminhtml\Container')->setTemplate('NS8_Protect::order_client_iframe.phtml')->toHtml(); ?>
 </section>
 

--- a/view/adminhtml/templates/order_client_iframe.phtml
+++ b/view/adminhtml/templates/order_client_iframe.phtml
@@ -4,28 +4,30 @@ $block = $block;
 ?>
 
 <script type="text/javascript" src="<?= $block->url->getProtectClientSdkUrl() ?>"></script>
-<script type="text/javascript">
-    function navigateToMagentoOrderDetails(orderData) {
-      var orderDetailsUrlBase = '<?= $block->url->getMagentOrderDetailUrl(); ?>';
-      window.location.href = orderDetailsUrlBase + '/' + orderData.orderId;
-    }
-    
-    var orderIncrementId = '<?= $block->getOrderIncrementIdFromRequest(); ?>';
-    var containerElementId = 'ns8-protect-wrapper';
-    var clientConfig = new Protect.ClientConfig({
-        accessToken: '<?= $block->getAccessToken(); ?>',
-        protectClientUrl: '<?= $block->url->getClientUrl() ?>',
-        eventBinding: {
-          [Protect.EventName.ORDER_DETAIL_NAME_CLICK]: navigateToMagentoOrderDetails
-        },
-        iFrameConfig: {
-          attachToId: containerElementId,
-          classNames: ['ns8-protect-client-iframe'],
-        },
-      });
+<script>
+    require(['Protect'], function(Protect) {
+        function navigateToMagentoOrderDetails(orderData) {
+        var orderDetailsUrlBase = '<?= $block->url->getMagentOrderDetailUrl(); ?>';
+        window.location.href = orderDetailsUrlBase + '/' + orderData.orderId;
+        }
 
-    var protectClient = Protect.createClient(clientConfig);
-    $('#' + containerElementId).html('');
-    protectClient.render(requestedPage, orderIncrementId);
+        var requestedPage = '<?= $block->getPageFromRequest(); ?>' || Protect.ClientPage.DASHBOARD;
+        var orderIncrementId = '<?= $block->getOrderIncrementIdFromRequest(); ?>';
+        var containerElementId = 'ns8-protect-wrapper';
+        var clientConfig = new Protect.ClientConfig({
+            accessToken: '<?= $block->getInitialAccessToken(); ?>',
+            protectClientUrl: '<?= $block->url->getClientUrl() ?>',
+            eventBinding: {
+            [Protect.EventName.ORDER_DETAIL_NAME_CLICK]: navigateToMagentoOrderDetails
+            },
+            iFrameConfig: {
+            attachToId: containerElementId,
+            classNames: ['ns8-protect-client-iframe'],
+            },
+        });
+
+        var protectClient = Protect.createClient(clientConfig);
+        protectClient.render(requestedPage, orderIncrementId);
+  });
 </script>
 <div id="ns8-protect-wrapper"></div>

--- a/view/adminhtml/templates/order_client_iframe.phtml
+++ b/view/adminhtml/templates/order_client_iframe.phtml
@@ -1,0 +1,31 @@
+<?php
+/** @var NS8\Protect\Block\Adminhtml\StoreSelect */
+$block = $block; 
+?>
+
+<script type="text/javascript" src="<?= $block->url->getProtectClientSdkUrl() ?>"></script>
+<script type="text/javascript">
+    function navigateToMagentoOrderDetails(orderData) {
+      var orderDetailsUrlBase = '<?= $block->url->getMagentOrderDetailUrl(); ?>';
+      window.location.href = orderDetailsUrlBase + '/' + orderData.orderId;
+    }
+    
+    var orderIncrementId = '<?= $block->getOrderIncrementIdFromRequest(); ?>';
+    var containerElementId = 'ns8-protect-wrapper';
+    var clientConfig = new Protect.ClientConfig({
+        accessToken: '<?= $block->getAccessToken(); ?>',
+        protectClientUrl: '<?= $block->url->getClientUrl() ?>',
+        eventBinding: {
+          [Protect.EventName.ORDER_DETAIL_NAME_CLICK]: navigateToMagentoOrderDetails
+        },
+        iFrameConfig: {
+          attachToId: containerElementId,
+          classNames: ['ns8-protect-client-iframe'],
+        },
+      });
+
+    var protectClient = Protect.createClient(clientConfig);
+    $('#' + containerElementId).html('');
+    protectClient.render(requestedPage, orderIncrementId);
+</script>
+<div id="ns8-protect-wrapper"></div>

--- a/view/adminhtml/templates/order_client_iframe.phtml
+++ b/view/adminhtml/templates/order_client_iframe.phtml
@@ -7,8 +7,8 @@ $block = $block;
 <script>
     require(['Protect'], function(Protect) {
         function navigateToMagentoOrderDetails(orderData) {
-        var orderDetailsUrlBase = '<?= $block->url->getMagentOrderDetailUrl(); ?>';
-        window.location.href = orderDetailsUrlBase + '/' + orderData.orderId;
+            var orderDetailsUrlBase = '<?= $block->url->getMagentOrderDetailUrl(); ?>';
+            window.location.href = orderDetailsUrlBase + '/' + orderData.orderId;
         }
 
         var requestedPage = '<?= $block->getPageFromRequest(); ?>' || Protect.ClientPage.DASHBOARD;


### PR DESCRIPTION
# Story Reference

[CH-40216](https://app.clubhouse.io/ns8/story/40216/single-order-view-fails-to-render)

## Summary
Resolves an Issue with Order Detail pages failing to display Protect Client iFrame

## Author Checklist

I have added/updated:

- [N/A] Tests
- [N/A] Documentation
- [N/A] Release notes (title of this PR)

## Version Bump

- [X] Patch (bug fix - backwards compatible)
- [ ] Minor (new functionality - backwards compatible)
- [ ] Major (significant change - not backwards compatible)
