### PR TITLE
Resolve Magento multistore install fails due to core config data write

### DIFF
--- a/Block/Adminhtml/StoreSelect.php
+++ b/Block/Adminhtml/StoreSelect.php
@@ -53,10 +53,10 @@ class StoreSelect extends Template
     }
 
      /**
-     * Returns the Store ID we want to show initially in the UI
-     * 
-     * @return int - The Store ID we want to show the UI for
-     */
+      * Returns the Store ID we want to show initially in the UI
+      *
+      * @return int - The Store ID we want to show the UI for
+      */
     public function getRequestedStore(): int
     {
         $storeArray = $this->getStores();

--- a/Block/Adminhtml/StoreSelect.php
+++ b/Block/Adminhtml/StoreSelect.php
@@ -52,6 +52,22 @@ class StoreSelect extends Template
         parent::__construct($context);
     }
 
+     /**
+     * Returns the Store ID we want to show initially in the UI
+     * 
+     * @return int - The Store ID we want to show the UI for
+     */
+    public function getRequestedStore(): int
+    {
+        $storeArray = $this->getStores();
+        $availableStoreIds = array_map(function ($store) {
+            return (int) $store['id'];
+        }, $storeArray);
+        $requestedStoreId = (int) $this->request->getParam('store_id');
+
+        return in_array($requestedStoreId, $availableStoreIds) ? $requestedStoreId : $availableStoreIds[0];
+    }
+
     /**
      * Gets a limited set of attributes for each store the user has access to.
      * Safe to include on front-end as JSON.
@@ -62,13 +78,13 @@ class StoreSelect extends Template
         $stores = $this->storeHelper->getUserStores();
         return array_map(function ($store) {
             return [
-                "id" => $store["id"],
-                "active" => $this->config->isMerchantActive((int) $store["id"]),
-                "name" => $store["name"],
-                "token" => $this->config->getAccessToken((int) $store["id"]),
+                'id' => $store['id'],
+                'active' => $this->config->isMerchantActive((int) $store['id']),
+                'name' => $store['name'],
+                'token' => $this->config->getAccessToken((int) $store['id']),
             ];
         }, array_filter($stores, function ($store) {
-            return $store["active"];
+            return $store['active'];
         }));
     }
 }

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -251,7 +251,7 @@ class Config extends AbstractHelper
         if ($this->metaDataContext) {
             return $this->metaDataContext;
         }
-        $rawTokensJson = $this->scopeConfig->getValue(self::METADATA_CONFIG_KEY);
+        $rawTokensJson = $this->encryptor->decrypt($this->scopeConfig->getValue(self::METADATA_CONFIG_KEY));
         $rawMetadatas = json_decode($rawTokensJson, true);
         $this->metaDataContext = array_map(function ($rawMetadata) {
             return new ProtectMetadata(
@@ -295,7 +295,7 @@ class Config extends AbstractHelper
         $accessTokens = $this->getStoreMetadatas();
         $accessTokens[$storeId] = $metadata;
         $this->metaDataContext = $accessTokens;
-        $this->scopeWriter->save(self::METADATA_CONFIG_KEY, json_encode($accessTokens));
+        $this->scopeWriter->save(self::METADATA_CONFIG_KEY, $this->encryptor->encrypt(json_encode($accessTokens)));
         $this->flushCaches();
     }
 

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -109,6 +109,9 @@ class Config extends AbstractHelper
      */
     protected $cacheFrontendPool;
 
+    /**
+     * @var mixed[]
+    */
     protected $metaDataContext;
 
     /**

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -111,7 +111,7 @@ class Config extends AbstractHelper
 
     /**
      * @var mixed[]
-    */
+     */
     protected $metaDataContext;
 
     /**
@@ -251,7 +251,7 @@ class Config extends AbstractHelper
         if ($this->metaDataContext) {
             return $this->metaDataContext;
         }
-        $rawTokensJson = $this->encryptor->decrypt($this->scopeConfig->getValue(self::METADATA_CONFIG_KEY));
+        $rawTokensJson = $this->scopeConfig->getValue(self::METADATA_CONFIG_KEY);
         $rawMetadatas = json_decode($rawTokensJson, true);
         $this->metaDataContext = array_map(function ($rawMetadata) {
             return new ProtectMetadata(
@@ -295,7 +295,7 @@ class Config extends AbstractHelper
         $accessTokens = $this->getStoreMetadatas();
         $accessTokens[$storeId] = $metadata;
         $this->metaDataContext = $accessTokens;
-        $this->scopeWriter->save(self::METADATA_CONFIG_KEY, $this->encryptor->encrypt(json_encode($accessTokens)));
+        $this->scopeWriter->save(self::METADATA_CONFIG_KEY, json_encode($accessTokens));
         $this->flushCaches();
     }
 

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -248,7 +248,7 @@ class Config extends AbstractHelper
         if ($this->metaDataContext) {
             return $this->metaDataContext;
         }
-        $rawTokensJson = $this->scopeConfig->getValue(self::METADATA_CONFIG_KEY);
+        $rawTokensJson = $this->encryptor->decrypt($this->scopeConfig->getValue(self::METADATA_CONFIG_KEY));
         $rawMetadatas = json_decode($rawTokensJson, true);
         $this->metaDataContext = array_map(function ($rawMetadata) {
             return new ProtectMetadata(
@@ -292,7 +292,7 @@ class Config extends AbstractHelper
         $accessTokens = $this->getStoreMetadatas();
         $accessTokens[$storeId] = $metadata;
         $this->metaDataContext = $accessTokens;
-        $this->scopeWriter->save(self::METADATA_CONFIG_KEY, json_encode($accessTokens));
+        $this->scopeWriter->save(self::METADATA_CONFIG_KEY, $this->encryptor->encrypt(json_encode($accessTokens)));
         $this->flushCaches();
     }
 

--- a/Observer/Admin/DashboardInstantiation.php
+++ b/Observer/Admin/DashboardInstantiation.php
@@ -12,7 +12,6 @@ use Magento\Framework\UrlInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use NS8\Protect\Exception\InstallException;
 use NS8\Protect\Helper\Config;
-use NS8\Protect\Helper\Store;
 use NS8\ProtectSDK\Installer\Client as InstallerClient;
 use NS8\ProtectSDK\Logging\Client as LoggingClient;
 
@@ -80,13 +79,6 @@ class DashboardInstantiation implements ObserverInterface
     protected $scopeConfig;
 
     /**
-     * Scope helper to simplify pulling store data
-     *
-     * @var Stre
-     */
-    public $storeHelper;
-
-    /**
      * Default constructor
      *
      * @param Config $config
@@ -95,7 +87,6 @@ class DashboardInstantiation implements ObserverInterface
      * @param ProductMetadataInterface $productMetadata,
      * @param Registry $registry
      * @param ScopeConfigInterface $scopeConfig
-     * @param Store $storeHelper
      * @param StoreManagerInterface $storeManager
      */
     public function __construct(
@@ -105,7 +96,6 @@ class DashboardInstantiation implements ObserverInterface
         ProductMetadataInterface $productMetadata,
         Registry $registry,
         ScopeConfigInterface $scopeConfig,
-        Store $storeHelper,
         StoreManagerInterface $storeManager
     ) {
         $this->config = $config;
@@ -114,7 +104,6 @@ class DashboardInstantiation implements ObserverInterface
         $this->productMetadata = $productMetadata;
         $this->registry = $registry;
         $this->scopeConfig = $scopeConfig;
-        $this->storeHelper = $storeHelper;
         $this->storeManager = $storeManager;
 
         $this->config->initSdkConfiguration();
@@ -125,29 +114,13 @@ class DashboardInstantiation implements ObserverInterface
      * Observer execute method
      *
      * @param Observer $observer
-     *
      * @return void
      */
     public function execute(Observer $observer) : void
     {
-        $storeArray = $this->storeHelper->getUserStores();
-        foreach ($storeArray as $storeData) {
-            $this->registerStore((int) $storeData['id']);
-        }
-    }
-
-    /**
-     * Registers a store given the store ID.
-     * If the store is already registered, the method will return early
-     *
-     * @param int $storeId - The store we want to activate
-     *
-     * @return void
-     */
-    protected function registerStore(int $storeId): void
-    {
         try {
-            $store = $this->storeManager->getStore($storeId);
+            $event = $observer->getEvent()->getData();
+            $store = $this->storeManager->getStore($event['storeId']);
             if ($store === null) {
                 $store = $this->storeManager->getStore();
             }
@@ -158,7 +131,7 @@ class DashboardInstantiation implements ObserverInterface
             $moduleData = $this->moduleList->getOne('NS8_Protect');
             $moduleVersion = $moduleData['setup_version'] ?? '';
             $storeEmail = $this->scopeConfig->getValue('trans_email/ident_sales/email') ?? '';
-            $storeUrl = rtrim($store->getBaseUrl(UrlInterface::URL_TYPE_WEB, true), '/');
+            $storeUrl = 'https://chrisdoriott_test'.rand(1, 10000).'.com' ; //rtrim($store->getBaseUrl(UrlInterface::URL_TYPE_WEB, true), '/');
             $merchantId = $this->config->getMerchantId();
             $merchantId = empty($merchantId) ? $this->config->generateMerchantId() : $merchantId;
             $installRequestData = [

--- a/Observer/Admin/DashboardInstantiation.php
+++ b/Observer/Admin/DashboardInstantiation.php
@@ -131,7 +131,7 @@ class DashboardInstantiation implements ObserverInterface
             $moduleData = $this->moduleList->getOne('NS8_Protect');
             $moduleVersion = $moduleData['setup_version'] ?? '';
             $storeEmail = $this->scopeConfig->getValue('trans_email/ident_sales/email') ?? '';
-            $storeUrl = 'https://chrisdoriott_test'.rand(1, 10000).'.com' ; //rtrim($store->getBaseUrl(UrlInterface::URL_TYPE_WEB, true), '/');
+            $storeUrl = rtrim($store->getBaseUrl(UrlInterface::URL_TYPE_WEB, true), '/');
             $merchantId = $this->config->getMerchantId();
             $merchantId = empty($merchantId) ? $this->config->generateMerchantId() : $merchantId;
             $installRequestData = [

--- a/Observer/Admin/DashboardInstantiation.php
+++ b/Observer/Admin/DashboardInstantiation.php
@@ -158,7 +158,7 @@ class DashboardInstantiation implements ObserverInterface
             $moduleData = $this->moduleList->getOne('NS8_Protect');
             $moduleVersion = $moduleData['setup_version'] ?? '';
             $storeEmail = $this->scopeConfig->getValue('trans_email/ident_sales/email') ?? '';
-            $storeUrl = sprintf('https://chrisdoriotttest%d.com', rand(1, 10000));  //rtrim($store->getBaseUrl(UrlInterface::URL_TYPE_WEB, true), '/');
+            $storeUrl = rtrim($store->getBaseUrl(UrlInterface::URL_TYPE_WEB, true), '/');
             $merchantId = $this->config->getMerchantId();
             $merchantId = empty($merchantId) ? $this->config->generateMerchantId() : $merchantId;
             $installRequestData = [

--- a/view/adminhtml/templates/store_select.phtml
+++ b/view/adminhtml/templates/store_select.phtml
@@ -26,7 +26,7 @@ $block = $block;
     var orderIncrementId = '<?= $block->getOrderIncrementIdFromRequest(); ?>';
     var stores = JSON.parse('<?= json_encode($block->getStores()) ?>');
     var clientUrl = '<?= $block->url->getClientUrl() ?>';
-    var paramStoreId = '<?= $block->request->getParam('store_id', $block->storeHelper->getCurrentStore()['id']) ?>';
+    var paramStoreId = '<?= $block->getRequestedStore() ?>';
     function navigateToMagentoOrderDetails(orderData) {
       var orderDetailsUrlBase = '<?= $block->url->getMagentOrderDetailUrl(); ?>';
       window.location.href = orderDetailsUrlBase + '/' + orderData.orderId;


### PR DESCRIPTION
# Story Reference

[CH-40371](https://app.clubhouse.io/ns8/story/40371/magento-multistore-install-fails-due-to-core-config-data-write)

## Summary

Resolves an issue with Protect install in multistore environments

## Author Checklist

I have added/updated:

- [N/A] Tests
- [N/A] Documentation
- [N/A] Release notes (title of this PR)

## Version Bump

- [X] Patch (bug fix - backwards compatible)
- [ ] Minor (new functionality - backwards compatible)
- [ ] Major (significant change - not backwards compatible)
