### PR TITLE
[40721] add nulling functions to token set command

### DIFF
--- a/Console/Command/SetAccessToken.php
+++ b/Console/Command/SetAccessToken.php
@@ -69,8 +69,11 @@ class SetAccessToken extends Command
         $storeId = $input->getOption(self::STORE_ID);
         $token = $input->getArgument(self::TOKEN);
         $active = $input->getOption(self::ACTIVE);
-
+        if ($token === 'null') {
+            $token = null;
+        }
         $this->config->setAccessToken($storeId, $token);
+
         if ($active !== null) {
             $this->config->setIsMerchantActive($storeId, $active === 'true');
         }

--- a/Helper/Data/ProtectMetadata.php
+++ b/Helper/Data/ProtectMetadata.php
@@ -9,7 +9,7 @@ class ProtectMetadata
     /** @var bool */
     public $isActive;
 
-    public function __construct(string $token, bool $isActive)
+    public function __construct(?string $token, bool $isActive)
     {
         $this->token = $token;
         $this->isActive = $isActive;

--- a/Helper/Store.php
+++ b/Helper/Store.php
@@ -41,7 +41,7 @@ class Store extends AbstractHelper
     }
 
     /**
-     *  formats a single store into a more succinct and usable array
+     * Formats a single store into a more succinct and usable array
      * @param Store $store
      * @return array
      */
@@ -71,7 +71,7 @@ class Store extends AbstractHelper
     }
 
     /**
-     * get all stores
+     * Get all stores
      *
      * @return array
      */
@@ -82,7 +82,7 @@ class Store extends AbstractHelper
     }
 
     /**
-     * get all stores under a website
+     * Get all stores under a website
      * @param int $websiteId - the id if the desired website
      * @return array
      */


### PR DESCRIPTION
# Story Reference

[40721](https://app.clubhouse.io/ns8/story/40721)

## Summary

Allow a null access token to be passed to setAccessToken, and map the string 'null' to the null value in the protect:token:set command

## Author Checklist

I have added/updated:

- [ ] Tests
- [ ] Documentation
- [ ] Release notes (title of this PR)

## Version Bump

- [ ] Patch (bug fix - backwards compatible)
- [x] Minor (new functionality - backwards compatible)
- [ ] Major (significant change - not backwards compatible)
