### PR TITLE
Updating Conditional for registration to only check if the store is active instead of validating token access CH-39706

### DIFF
--- a/Observer/Admin/DashboardInstantiation.php
+++ b/Observer/Admin/DashboardInstantiation.php
@@ -125,7 +125,7 @@ class DashboardInstantiation implements ObserverInterface
                 $store = $this->storeManager->getStore();
             }
             $meta = $this->config->getStoreMetadata($store->getStoreId());
-            if ($meta && ($meta->isActive || $meta->token)) {
+            if ($meta && $meta->isActive) {
                 return;
             }
             $moduleData = $this->moduleList->getOne('NS8_Protect');


### PR DESCRIPTION


# Story Reference

[CH-39706](https://app.clubhouse.io/ns8/story/39706/bug-protect-in-magento-shows-500-internal-server-error-after-reinstall)

## Summary

Resolves an issue where uninstall to reinstall fails due to a token being present but the merchant is not yet active in Protect

## Author Checklist

I have added/updated:

- [N/A] Tests
- [N/A] Documentation
- [X] Release notes (title of this PR)

## Version Bump

- [X] Patch (bug fix - backwards compatible)
- [ ] Minor (new functionality - backwards compatible)
- [ ] Major (significant change - not backwards compatible)
