### PR TITLE
EQ8 score links in magento do not redirect you to protect s order details page

### DIFF
--- a/Block/Adminhtml/Container.php
+++ b/Block/Adminhtml/Container.php
@@ -42,6 +42,11 @@ class Container extends Template
     public $config;
 
     /**
+     * @var Url
+     */
+    public $url;
+
+    /**
      * The context.
      *
      * @var Context
@@ -118,32 +123,5 @@ class Container extends Template
         $accessToken = $this->config->getAccessToken($storeId);
 
         return (string) $accessToken;
-    }
-
-    /**
-     * Get the page to navigate to within the protect client
-     *
-     * @return string The name of the page to naviage to.
-     */
-    public function getPageFromRequest(): string
-    {
-        $page = (string)$this->request->getParam('page');
-        $orderIncrementId = $this->getOrderIncrementIdFromRequest();
-        if (empty($page) && !empty($orderIncrementId)) {
-            $page = ClientSdkClient::CLIENT_PAGE_ORDER_DETAILS;
-        }
-
-        return $page;
-    }
-
-    /**
-     * Get the URL of the iframe that holds the NS8 Protect client.
-     *
-     * @return string The URL
-     */
-    public function getOrderIncrementIdFromRequest(): string
-    {
-        $orderId = $this->request->getParam('order_id');
-        return $orderId ? $this->order->getOrderIncrementId($orderId) : '';
     }
 }

--- a/Block/Adminhtml/StoreSelect.php
+++ b/Block/Adminhtml/StoreSelect.php
@@ -2,7 +2,6 @@
 
 namespace NS8\Protect\Block\Adminhtml;
 
-use Magento\Backend\Block\Template;
 use Magento\Backend\Block\Template\Context;
 use Magento\Framework\App\Request\Http;
 use Magento\Store\Model\StoreManagerInterface;
@@ -13,7 +12,7 @@ use NS8\Protect\Helper\Url;
 /**
  * Provides access to DI and helper methods for the store_select template
  */
-class StoreSelect extends Template
+class StoreSelect extends Container
 {
     /** @var Config */
     protected $config;

--- a/Block/Adminhtml/StoreSelect.php
+++ b/Block/Adminhtml/StoreSelect.php
@@ -2,6 +2,7 @@
 
 namespace NS8\Protect\Block\Adminhtml;
 
+use Magento\Backend\Block\Template;
 use Magento\Backend\Block\Template\Context;
 use Magento\Framework\App\Request\Http;
 use Magento\Store\Model\StoreManagerInterface;
@@ -12,7 +13,7 @@ use NS8\Protect\Helper\Url;
 /**
  * Provides access to DI and helper methods for the store_select template
  */
-class StoreSelect extends Container
+class StoreSelect extends Template
 {
     /** @var Config */
     protected $config;
@@ -66,6 +67,26 @@ class StoreSelect extends Container
 
         return in_array($requestedStoreId, $availableStoreIds) ? $requestedStoreId : $availableStoreIds[0];
     }
+
+    /**
+     * Get the page to navigate to within the protect client
+     *
+     * @return string Access token to use initially upon page render
+     */
+    public function getInitialStoreId() : string
+    {
+        $orderId = $this->request->getParam('order_id');
+        if (empty($orderId)) {
+            return '';
+        }
+
+        $order = $this->order->getOrder();
+        $storeId = $order ? (int) $order->getStoreId() : null;
+        $accessToken = $this->config->getAccessToken($storeId);
+
+        return (string) $accessToken;
+    }
+
 
     /**
      * Gets a limited set of attributes for each store the user has access to.

--- a/Block/Adminhtml/StoreSelect.php
+++ b/Block/Adminhtml/StoreSelect.php
@@ -87,7 +87,6 @@ class StoreSelect extends Template
         return (string) $accessToken;
     }
 
-
     /**
      * Gets a limited set of attributes for each store the user has access to.
      * Safe to include on front-end as JSON.

--- a/Block/Adminhtml/StoreSelect.php
+++ b/Block/Adminhtml/StoreSelect.php
@@ -7,6 +7,7 @@ use Magento\Backend\Block\Template\Context;
 use Magento\Framework\App\Request\Http;
 use Magento\Store\Model\StoreManagerInterface;
 use NS8\Protect\Helper\Config;
+use NS8\Protect\Helper\Order;
 use NS8\Protect\Helper\Store;
 use NS8\Protect\Helper\Url;
 
@@ -17,6 +18,13 @@ class StoreSelect extends Template
 {
     /** @var Config */
     protected $config;
+
+    /**
+     * The order helper.
+     *
+     * @var Order
+     */
+    public $order;
 
     /** @var Url */
     public $url;
@@ -36,19 +44,22 @@ class StoreSelect extends Template
      * @param Config $config Config helper
      * @param Url $url Url helper
      * @param Http $request request object
+     * @param Order $order The order helper
      * @param Store $storeHelper Store helper
      */
     public function __construct(
         Context $context,
         Config $config,
-        Url $url,
         Http $request,
-        Store $storeHelper
+        Order $order,
+        Store $storeHelper,
+        Url $url
     ) {
         $this->config = $config;
-        $this->url = $url;
+        $this->order = $order;
         $this->storeHelper = $storeHelper;
         $this->request = $request;
+        $this->url = $url;
         parent::__construct($context);
     }
 
@@ -66,25 +77,6 @@ class StoreSelect extends Template
         $requestedStoreId = (int) $this->request->getParam('store_id');
 
         return in_array($requestedStoreId, $availableStoreIds) ? $requestedStoreId : $availableStoreIds[0];
-    }
-
-    /**
-     * Get the page to navigate to within the protect client
-     *
-     * @return string Access token to use initially upon page render
-     */
-    public function getInitialStoreId() : string
-    {
-        $orderId = $this->request->getParam('order_id');
-        if (empty($orderId)) {
-            return '';
-        }
-
-        $order = $this->order->getOrder();
-        $storeId = $order ? (int) $order->getStoreId() : null;
-        $accessToken = $this->config->getAccessToken($storeId);
-
-        return (string) $accessToken;
     }
 
     /**

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -519,6 +519,33 @@ class Order extends AbstractHelper
     }
 
     /**
+     * Get the URL of the iframe that holds the NS8 Protect client.
+     *
+     * @return string The URL
+     */
+    public function getOrderIncrementIdFromRequest(): string
+    {
+        $orderId = $this->request->getParam('order_id');
+        return $orderId ? $this->getOrderIncrementId($orderId) : '';
+    }
+
+    /**
+     * Get the page to navigate to within the protect client
+     *
+     * @return string The name of the page to naviage to.
+     */
+    public function getPageFromRequest(): string
+    {
+        $page = (string)$this->request->getParam('page');
+        $orderIncrementId = $this->getOrderIncrementIdFromRequest();
+        if (empty($page) && !empty($orderIncrementId)) {
+            $page = ClientSdkClient::CLIENT_PAGE_ORDER_DETAILS;
+        }
+
+        return $page;
+    }
+
+    /**
      * Gets all of the data associated with an order
      *
      * @param OrderInterface $order

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -279,8 +279,14 @@ class Order extends AbstractHelper
         if (!isset($orderId) || !isset($eq8Score)) {
             return 'NA';
         }
+
+        $order = $this->getOrder($orderId);
         $link = $this->url->getNS8IframeUrl(
-            ['page' => ClientSdkClient::CLIENT_PAGE_ORDER_DETAILS, 'order_id' => $orderId]
+            [
+                'page' => ClientSdkClient::CLIENT_PAGE_ORDER_DETAILS,
+                'order_id' => $orderId,
+                'store_id' => $order->getStoreId()
+            ]
         );
         return '<a href="'.$link.'">'.$eq8Score.'</a>';
     }

--- a/Helper/Url.php
+++ b/Helper/Url.php
@@ -3,7 +3,6 @@
 namespace NS8\Protect\Helper;
 
 use Magento\Framework\App\Helper\AbstractHelper;
-use Magento\Framework\App\Request\Http;
 use Magento\Framework\UrlInterface;
 use Magento\Backend\Model\UrlInterface as BackendUrlInterface;
 use Magento\Framework\App\State;
@@ -39,34 +38,24 @@ class Url extends AbstractHelper
     protected $config;
 
     /**
-     * The request.
-     *
-     * @var Http
-     */
-    protected $request;
-
-    /**
      * The constructor.
      *
-     * @param BackendUrlInterface $backendUrl
-     * @param Config $config
-     * @param Http $request The request
-     * @param State $state
      * @param UrlInterface $url
+     * @param BackendUrlInterface $backendUrl
+     * @param State $state,
+     * @param Config $config
      *
      */
     public function __construct(
+        UrlInterface $url,
         BackendUrlInterface $backendUrl,
-        Config $config,
-        Http $request,
         State $state,
-        UrlInterface $url
+        Config $config
     ) {
-        $this->backendUrl = $backendUrl;
-        $this->config = $config;
-        $this->request = $request;
-        $this->state = $state;
         $this->url = $url;
+        $this->backendUrl = $backendUrl;
+        $this->state = $state;
+        $this->config = $config;
     }
 
     /**
@@ -129,40 +118,8 @@ class Url extends AbstractHelper
         return ClientSdk::getClientSdkUrl();
     }
 
-    /**
-     * Gets the protect-sdk-client URL
-     *
-     * @return string The URL
-     */
     public function getClientUrl(): string
     {
         return SdkConfigManager::getEnvValue('urls.client_url');
-    }
-
-    /**
-     * Get the page to navigate to within the protect client
-     *
-     * @return string The name of the page to naviage to.
-     */
-    public function getPageFromRequest(): string
-    {
-        $page = (string)$this->request->getParam('page');
-        $orderIncrementId = $this->getOrderIncrementIdFromRequest();
-        if (empty($page) && !empty($orderIncrementId)) {
-            $page = ClientSdkClient::CLIENT_PAGE_ORDER_DETAILS;
-        }
-
-        return $page;
-    }
-
-    /**
-     * Get the URL of the iframe that holds the NS8 Protect client.
-     *
-     * @return string The URL
-     */
-    public function getOrderIncrementIdFromRequest(): string
-    {
-        $orderId = $this->request->getParam('order_id');
-        return $orderId ? $this->order->getOrderIncrementId($orderId) : '';
     }
 }

--- a/view/adminhtml/templates/order_client_iframe.phtml
+++ b/view/adminhtml/templates/order_client_iframe.phtml
@@ -11,8 +11,8 @@ $block = $block;
             window.location.href = orderDetailsUrlBase + '/' + orderData.orderId;
         }
 
-        var requestedPage = '<?= $block->url->getPageFromRequest(); ?>' || Protect.ClientPage.DASHBOARD;
-        var orderIncrementId = '<?= $block->url>getOrderIncrementIdFromRequest(); ?>';
+        var requestedPage = '<?= $block->order->getPageFromRequest(); ?>' || Protect.ClientPage.DASHBOARD;
+        var orderIncrementId = '<?= $block->order>getOrderIncrementIdFromRequest(); ?>';
         var containerElementId = 'ns8-protect-wrapper';
         var clientConfig = new Protect.ClientConfig({
             accessToken: '<?= $block->getInitialAccessToken(); ?>',

--- a/view/adminhtml/templates/order_client_iframe.phtml
+++ b/view/adminhtml/templates/order_client_iframe.phtml
@@ -1,6 +1,6 @@
 <?php
 /** @var NS8\Protect\Block\Adminhtml\StoreSelect */
-$block = $block; 
+$block = $block;
 ?>
 
 <script type="text/javascript" src="<?= $block->url->getProtectClientSdkUrl() ?>"></script>
@@ -11,8 +11,8 @@ $block = $block;
             window.location.href = orderDetailsUrlBase + '/' + orderData.orderId;
         }
 
-        var requestedPage = '<?= $block->getPageFromRequest(); ?>' || Protect.ClientPage.DASHBOARD;
-        var orderIncrementId = '<?= $block->getOrderIncrementIdFromRequest(); ?>';
+        var requestedPage = '<?= $block->url->getPageFromRequest(); ?>' || Protect.ClientPage.DASHBOARD;
+        var orderIncrementId = '<?= $block->url>getOrderIncrementIdFromRequest(); ?>';
         var containerElementId = 'ns8-protect-wrapper';
         var clientConfig = new Protect.ClientConfig({
             accessToken: '<?= $block->getInitialAccessToken(); ?>',

--- a/view/adminhtml/templates/store_select.phtml
+++ b/view/adminhtml/templates/store_select.phtml
@@ -22,8 +22,8 @@ $block = $block;
     // this isn't compiled, so we have to use old JS to work in old browsers
     var containerElementId = 'ns8-protect-wrapper';
     // load a bunch of data from PHP
-    var requestedPage = '<?= $block->getPageFromRequest(); ?>' || Protect.ClientPage.DASHBOARD;
-    var orderIncrementId = '<?= $block->getOrderIncrementIdFromRequest(); ?>';
+    var requestedPage = '<?= $block->url->getPageFromRequest(); ?>' || Protect.ClientPage.DASHBOARD;
+    var orderIncrementId = '<?= $block->url->getOrderIncrementIdFromRequest(); ?>';
     var stores = JSON.parse('<?= json_encode($block->getStores()) ?>');
     var clientUrl = '<?= $block->url->getClientUrl() ?>';
     var paramStoreId = '<?= $block->getRequestedStore() ?>';

--- a/view/adminhtml/templates/store_select.phtml
+++ b/view/adminhtml/templates/store_select.phtml
@@ -22,8 +22,8 @@ $block = $block;
     // this isn't compiled, so we have to use old JS to work in old browsers
     var containerElementId = 'ns8-protect-wrapper';
     // load a bunch of data from PHP
-    var requestedPage = '<?= $block->url->getPageFromRequest(); ?>' || Protect.ClientPage.DASHBOARD;
-    var orderIncrementId = '<?= $block->url->getOrderIncrementIdFromRequest(); ?>';
+    var requestedPage = '<?= $block->order->getPageFromRequest(); ?>' || Protect.ClientPage.DASHBOARD;
+    var orderIncrementId = '<?= $block->order->getOrderIncrementIdFromRequest(); ?>';
     var stores = JSON.parse('<?= json_encode($block->getStores()) ?>');
     var clientUrl = '<?= $block->url->getClientUrl() ?>';
     var paramStoreId = '<?= $block->getRequestedStore() ?>';


### PR DESCRIPTION
# Story Reference

[CH-40999]https://app.clubhouse.io/ns8/story/40999/eq8-score-links-in-magento-do-not-redirect-you-to-protect-s-order-details-page_)

## Summary

__REPLACE__

## Author Checklist

I have added/updated:

- [N/A] Tests
- [N/A] Documentation
- [X] Release notes (title of this PR)

## Version Bump

- [X] Patch (bug fix - backwards compatible)
- [ ] Minor (new functionality - backwards compatible)
- [ ] Major (significant change - not backwards compatible)
