### PR TITLE
Fixing dash resulting in syntax error CH-40999

### DIFF
--- a/view/adminhtml/templates/order_client_iframe.phtml
+++ b/view/adminhtml/templates/order_client_iframe.phtml
@@ -12,7 +12,7 @@ $block = $block;
         }
 
         var requestedPage = '<?= $block->order->getPageFromRequest(); ?>' || Protect.ClientPage.DASHBOARD;
-        var orderIncrementId = '<?= $block->order>getOrderIncrementIdFromRequest(); ?>';
+        var orderIncrementId = '<?= $block->order->getOrderIncrementIdFromRequest(); ?>';
         var containerElementId = 'ns8-protect-wrapper';
         var clientConfig = new Protect.ClientConfig({
             accessToken: '<?= $block->getInitialAccessToken(); ?>',


### PR DESCRIPTION
# Story Reference

[CH-40999](https://app.clubhouse.io/ns8/story/40999/eq8-score-links-in-magento-do-not-redirect-you-to-protect-s-order-details-page)

## Summary
Resolves a bug due to a missing `-`


## Author Checklist

I have added/updated:

- [N/A] Tests
- [N/A] Documentation
- [X] Release notes (title of this PR)

## Version Bump

- [X] Patch (bug fix - backwards compatible)
- [ ] Minor (new functionality - backwards compatible)
- [ ] Major (significant change - not backwards compatible)
