### PR TITLE
Fix storefront loading for deactivated stores.

### DIFF
--- a/Block/Frontend/Script.php
+++ b/Block/Frontend/Script.php
@@ -68,7 +68,13 @@ class Script extends Template
      */
     public function getScriptHtml(): string
     {
-        $this->config->initSdkConfiguration(true, (int)$this->storeManager->getStore()->getId());
+        $storeId = (int)$this->storeManager->getStore()->getId();
+
+        if (!$this->config->isMerchantActive($storeId)) {
+            return '';
+        }
+
+        $this->config->initSdkConfiguration(true, $storeId);
         $script = AnalyticsClient::getTrueStatsScript();
 
         return is_string($script) ? sprintf('<script>%s</script>', $script) : '';


### PR DESCRIPTION
# Story Reference

[ch41345](https://app.clubhouse.io/ns8/story/41345/storefront-temporarily-breaks-when-ns8-protect-is-inactive)

## Summary

If a store is not active in NS8 Protect, then we don't want to load the TrueStats script on its storefront (because we probably don't have an access token).

## Author Checklist

I have added/updated:

- [ ] Tests
- [ ] Documentation
- [X] Release notes (title of this PR)

## Version Bump

- [X] Patch (bug fix - backwards compatible)
- [ ] Minor (new functionality - backwards compatible)
- [ ] Major (significant change - not backwards compatible)
