### PR TITLE
Small bug fix in SetAccessToken command

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -185,7 +185,7 @@ class Config extends AbstractHelper
     public function setIsMerchantActive(?int $storeId, bool $isActive): void
     {
         $token = $this->getAccessToken($storeId);
-        if ($token === null) { // no need to set isActive when no token exists
+        if ($token === null && $isActive) { // no need to set isActive when no token exists
             return;
         }
         $metadata = new ProtectMetadata($token, $isActive);

--- a/Test/Helper/ConfigTest.php
+++ b/Test/Helper/ConfigTest.php
@@ -169,6 +169,30 @@ class ConfigTest extends TestCase
         ]);
     }
 
+    /** Config::setIsMerchantActive() should not activate a store with a null token */
+    public function testSetIsMerchantActiveWontActivateWithNullToken(): void
+    {
+        $this->setMetadatas([
+            '1' => new ProtectMetadata(null, false)
+        ]);
+        $this->config->setIsMerchantActive(1, true);
+        $this->assertScopeConfig([
+            '1' => new ProtectMetadata(null, false)
+        ]);
+    }
+
+    /** Config::setIsMerchantActive() should deactivate a store with a null token */
+    public function testSetIsMerchantActiveWillDectivateWithNullToken(): void
+    {
+        $this->setMetadatas([
+            '1' => new ProtectMetadata(null, true)
+        ]);
+        $this->config->setIsMerchantActive(1, false);
+        $this->assertScopeConfig([
+            '1' => new ProtectMetadata(null, false)
+        ]);
+    }
+
     /** Config::setIsMerchantActive() should set multiple stores' isActive */
     public function testSetIsMerchantActiveSetsMultiple(): void
     {


### PR DESCRIPTION
## Summary

This just fixes a tiny bug that occurs when you try to deactivate a store _and_ set its token to `null`. (The token gets nulled first, after which the deactivation silently fails, so you end up with a tokenless store that's still active.)

## Author Checklist

I have added/updated:

- [X] Tests
- [ ] Documentation
- [X] Release notes (title of this PR)

## Version Bump

- [X] Patch (bug fix - backwards compatible)
- [ ] Minor (new functionality - backwards compatible)
- [ ] Major (significant change - not backwards compatible)
