### PR TITLE
[40595] removing the as key from the store grid reference block 

### DIFF
--- a/view/adminhtml/layout/adminhtml_system_store_grid_block.xml
+++ b/view/adminhtml/layout/adminhtml_system_store_grid_block.xml
@@ -8,13 +8,13 @@
           template="NS8_Protect::protect_column_js.phtml" />
       </referenceContainer>
         <referenceBlock name="adminhtml.system.store.container">
-            <referenceBlock class="Magento\Backend\Block\Widget\Grid" name="adminhtml.system.store.grid" as="grid">
+            <referenceBlock class="Magento\Backend\Block\Widget\Grid" name="adminhtml.system.store.grid">
                 <arguments>
                     <argument name="id" xsi:type="string">storeGrid</argument>
                     <argument name="save_parameters_in_session" xsi:type="string">1</argument>
                     <argument name="dataSource" xsi:type="object" shared="false">Magento\Store\Model\ResourceModel\Website\Grid\Collection</argument>
                 </arguments>
-                <referenceBlock class="Magento\Backend\Block\Widget\Grid\ColumnSet" name="adminhtml.system.store.grid.columnSet" as="grid.columnSet">
+                <referenceBlock class="Magento\Backend\Block\Widget\Grid\ColumnSet" name="adminhtml.system.store.grid.columnSet">
                     <arguments>
                         <argument name="id" xsi:type="string">storeGrid</argument>
                     </arguments>


### PR DESCRIPTION

# Story Reference

[40595](https://app.clubhouse.io/ns8/story/40595)

## Summary

removing the as key from the store grid reference block since they are no longer supported in 2.3.5


## Author Checklist

I have added/updated:

- [ ] Tests
- [ ] Documentation
- [ ] Release notes (title of this PR)

## Version Bump

- [ ] Patch (bug fix - backwards compatible)
- [ ] Minor (new functionality - backwards compatible)
- [ ] Major (significant change - not backwards compatible)
