### PR TITLE
[42149] Multi-Store: If you navigate to the Protect dashboard while a store is inactive, you get a 500 error screen

### DIFF
--- a/Block/Adminhtml/StoreSelect.php
+++ b/Block/Adminhtml/StoreSelect.php
@@ -70,13 +70,7 @@ class StoreSelect extends Template
       */
     public function getRequestedStore(): int
     {
-        $storeArray = $this->getStores();
-        $availableStoreIds = array_map(function ($store) {
-            return (int) $store['id'];
-        }, $storeArray);
-        $requestedStoreId = (int) $this->request->getParam('store_id');
-
-        return in_array($requestedStoreId, $availableStoreIds) ? $requestedStoreId : $availableStoreIds[0];
+        return $this->storeHelper->getRequestedStoreId();
     }
 
     /**
@@ -86,16 +80,6 @@ class StoreSelect extends Template
      */
     public function getStores(): array
     {
-        $stores = $this->storeHelper->getUserStores();
-        return array_map(function ($store) {
-            return [
-                'id' => $store['id'],
-                'active' => $this->config->isMerchantActive((int) $store['id']),
-                'name' => $store['name'],
-                'token' => $this->config->getAccessToken((int) $store['id']),
-            ];
-        }, array_filter($stores, function ($store) {
-            return $store['active'];
-        }));
+        return $this->storeHelper->getDisplayStores();
     }
 }

--- a/Observer/Admin/DashboardInstantiation.php
+++ b/Observer/Admin/DashboardInstantiation.php
@@ -3,9 +3,9 @@ namespace NS8\Protect\Observer\Admin;
 
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
-use Magento\Store\Model\StoreManagerInterface;
 use NS8\Protect\Helper\Config;
 use NS8\Protect\Helper\Setup;
+use NS8\Protect\Helper\Store;
 
 /**
  * Responds to Dashboard init events
@@ -18,18 +18,21 @@ class DashboardInstantiation implements ObserverInterface
      * @var Config
      */
     protected $config;
-    /**
-     * Store manager attribute to fetch store data
-     *
-     * @var StoreManagerInterface
-     */
-    protected $storeManager;
+
     /**
      * Setup Helper attribute to activate a shop
      *
      * @var Setup
      */
     protected $setupHelper;
+
+    /**
+     * Store helper attribute to fetch store data
+     *
+     * @var Store
+     */
+    protected $storeHelper;
+
     /**
      * Default constructor
      *
@@ -40,10 +43,10 @@ class DashboardInstantiation implements ObserverInterface
     public function __construct(
         Config $config,
         Setup $setupHelper,
-        StoreManagerInterface $storeManager
+        Store $storeHelper
     ) {
         $this->config = $config;
-        $this->storeManager = $storeManager;
+        $this->storeHelper = $storeHelper;
         $this->setupHelper = $setupHelper;
         $this->config->initSdkConfiguration();
     }
@@ -56,15 +59,11 @@ class DashboardInstantiation implements ObserverInterface
      */
     public function execute(Observer $observer) : void
     {
-        $event = $observer->getEvent()->getData();
-        $store = $this->storeManager->getStore($event['storeId']);
-        if ($store === null) {
-            $store = $this->storeManager->getStore();
-        }
-        $meta = $this->config->getStoreMetadata($store->getStoreId());
+        $storeId = $this->storeHelper->getRequestedStoreId();
+        $meta = $this->config->getStoreMetadata($storeId);
         if ($meta && $meta->isActive && $meta->token) {
             return;
         }
-        $this->setupHelper->activateShop($store->getStoreId());
+        $this->setupHelper->activateShop($storeId);
     }
 }

--- a/Test/Helper/StoreTest.php
+++ b/Test/Helper/StoreTest.php
@@ -7,9 +7,11 @@ namespace NS8\Protect\Test;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Store\Model\ResourceModel\Store\Collection;
 use Magento\Framework\App\Helper\Context;
+use Magento\Framework\App\Request\Http;
 use Magento\Store\Model\StoreFactory;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\Store\Model\Store;
+use NS8\Protect\Helper\Config as Config;
 use NS8\Protect\Helper\Store as StoreHelper;
 use PHPUnit\Framework\TestCase;
 use Zend\Uri\Uri;
@@ -89,11 +91,16 @@ class StoreTest extends TestCase
         $storeFactoryTemp->method('create')->willReturn($storeMock);
         $storeFactory = $storeFactoryTemp;
 
+        $configHelper = $this->createMock(Config::class);
+        $request = $this->createMock(Http::class);
+
         $this->store1 = $store1;
         $this->store2 = $store2;
 
         $this->store = new StoreHelper(
             $context,
+            $configHelper,
+            $request,
             $storeFactory,
             $storeManager
         );


### PR DESCRIPTION

# Story Reference

[42149](https://app.clubhouse.io/ns8/story/42149)

## Summary

extracted getStores and getRequestedStores to the stores helper so they can also be called in DashboardInstantiation

*note: I had to leave the getStores and getRequestedStore functions in the StoreSelect block, because for some reason if I removed them, the store select code would fail to load.
## Author Checklist

I have added/updated:

- [ ] Tests
- [ ] Documentation
- [x] Release notes (title of this PR)

## Version Bump

- [x] Patch (bug fix - backwards compatible)
- [ ] Minor (new functionality - backwards compatible)
- [ ] Major (significant change - not backwards compatible)
