### PR TITLE
[38702]   Add EQ8 color coding to v2 Admin panel

### DIFF
--- a/Helper/Store.php
+++ b/Helper/Store.php
@@ -7,6 +7,7 @@ use Magento\Framework\App\Request\Http;
 use Magento\Store\Model\StoreFactory;
 use Magento\Store\Model\StoreManagerInterface;
 use NS8\Protect\Helper\Config;
+use NS8\ProtectSDK\Merchants\Client as MerchantClient;
 
 class Store extends AbstractHelper
 {
@@ -44,12 +45,15 @@ class Store extends AbstractHelper
         Config $configHelper,
         Http $request,
         StoreFactory $storeFactory,
-        StoreManagerInterface $storeManager
+        StoreManagerInterface $storeManager,
+        MerchantClient $merchantClient
     ) {
         $this->configHelper = $configHelper;
         $this->request = $request;
         $this->storeFactory = $storeFactory;
         $this->storeManager = $storeManager;
+        $this->merchantClient = $merchantClient;
+        $this->configHelper = $configHelper;
         parent::__construct($context);
     }
 
@@ -161,5 +165,18 @@ class Store extends AbstractHelper
             return $requestedStoreId;
         }
         return $availableStoreIds[0];
+    }
+
+    /**
+     * Retrieves the merchant record from Protect for a given shop
+     *
+     * @param int $storeId
+     * @return StdClass
+     */
+    public function getMerchantRecord(int $storeId): \StdClass
+    {
+        $this->configHelper->initSdkConfiguration(true, $storeId);
+        $ns8Merchant = $this->merchantClient->getCurrent();
+        return $ns8Merchant;
     }
 }

--- a/Test/Helper/OrderTest.php
+++ b/Test/Helper/OrderTest.php
@@ -13,6 +13,7 @@ use Magento\Sales\Model\ResourceModel\GridInterface;
 use Magento\Sales\Model\ResourceModel\Order\CollectionFactory;
 use NS8\Protect\Helper\Order as OrderHelper;
 use NS8\Protect\Helper\Protect as ProtectHelper;
+use NS8\Protect\Helper\Store as StoreHelper;
 use NS8\Protect\Helper\Url as UrlHelper;
 use NS8\Protect\Test\Mock\MockConnection;
 use NS8\Protect\Test\Mock\MockOrder;
@@ -77,6 +78,9 @@ class OrderTest extends TestCase
         /** @var ProtectHelper */
         $protectHelper = $protectHelperTemp;
 
+         /** @var StoreHelper */
+         $storeHelper = $this->createMock(StoreHelper::class);
+
         $this->orderHelper = new OrderHelper(
             $orderCollectionFactory,
             $config,
@@ -88,6 +92,7 @@ class OrderTest extends TestCase
             $request,
             $resourceConnection,
             $searchCriteriaBuilder,
+            $storeHelper,
             $transactionRepository,
             $urlHelper
         );

--- a/Test/Helper/StoreTest.php
+++ b/Test/Helper/StoreTest.php
@@ -13,6 +13,7 @@ use Magento\Store\Model\StoreManagerInterface;
 use Magento\Store\Model\Store;
 use NS8\Protect\Helper\Config as Config;
 use NS8\Protect\Helper\Store as StoreHelper;
+use NS8\ProtectSDK\Merchants\Client as MerchantClient;
 use PHPUnit\Framework\TestCase;
 use Zend\Uri\Uri;
 
@@ -95,6 +96,8 @@ class StoreTest extends TestCase
         $configHelper = $this->createMock(Config::class);
         $request = $this->createMock(Http::class);
 
+        $merchantClient = $this->createMock(MerchantClient::class);
+
         $this->store1 = $store1;
         $this->store2 = $store2;
 
@@ -103,7 +106,8 @@ class StoreTest extends TestCase
             $configHelper,
             $request,
             $storeFactory,
-            $storeManager
+            $storeManager,
+            $merchantClient
         );
     }
 

--- a/view/adminhtml/layout/default.xml
+++ b/view/adminhtml/layout/default.xml
@@ -1,0 +1,6 @@
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <head>
+        <css src="NS8_Protect::css/order_details_styles.css" />
+        <css src="NS8_Protect::css/dashboard_styles.css" />
+    </head>
+</page>

--- a/view/adminhtml/layout/ns8protectadmin_sales_dashboard.xml
+++ b/view/adminhtml/layout/ns8protectadmin_sales_dashboard.xml
@@ -6,7 +6,7 @@
     <title>NS8 Protect</title>
     <link src="requirejs/require.js"/>
     <css src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.13/css/select2.min.css" src_type="url" />
-    <css src="NS8_Protect::css/dashboard_styles.css" />
+
   </head>
   <body>
     <referenceContainer name="content">

--- a/view/adminhtml/ui_component/sales_order_grid.xml
+++ b/view/adminhtml/ui_component/sales_order_grid.xml
@@ -22,6 +22,7 @@
             xsi:type="boolean">false</item>
           <item name="sortOrder"
             xsi:type="number">200</item>
+          <item name="fieldClass" xsi:type="string">ns8</item>
         </item>
       </argument>
     </column>

--- a/view/adminhtml/web/css/order_details_styles.css
+++ b/view/adminhtml/web/css/order_details_styles.css
@@ -49,3 +49,32 @@ iframe.ns8-protect-client-iframe {
   height: 100%;
   border: 0;
 }
+
+.ns8-risk-high, .ns8-risk-med, .ns8-risk-low {
+  color: white;
+  border: 6px solid;
+  border-radius: 5px;
+}
+
+.ns8-risk-high:hover, .ns8-risk-med:hover, .ns8-risk-low:hover {
+  color: white;
+}
+
+.ns8-risk-high {
+  background-color: #ef442e;
+  border-color: #ef442e;
+}
+
+.ns8-risk-med {
+  background-color: #f8991d;
+  border-color: #f8991d;
+}
+
+.ns8-risk-low {
+  background-color: #78c143;
+  border-color: #78c143;
+}
+
+.ns8 div.data-grid-cell-content {
+  overflow: visible;
+}


### PR DESCRIPTION
# Story Reference

[38702](https://app.clubhouse.io/ns8/story/38702)

## Summary

wrap eq8 scores in a colored badge corresponding to the risk threshold loaded from protect
* moved css loading to be loaded in the default block as we can't seem to load custom css with the order's table as defined. Also per Magento documentation, universally loading css in admin is preferred for performance reasons

![Screen Shot 2020-08-20 at 5 29 41 PM](https://user-images.githubusercontent.com/1503561/90827735-c1debe80-e30a-11ea-983d-983f795988f2.png)

## Author Checklist

I have added/updated:

- [ ] Tests
- [ ] Documentation
- [x] Release notes (title of this PR)

## Version Bump

- [ ] Patch (bug fix - backwards compatible)
- [x] Minor (new functionality - backwards compatible)
- [ ] Major (significant change - not backwards compatible)
